### PR TITLE
Add steering committee members to governance repo.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,3 +5,20 @@ This repo contains documents that describe the governance practices for the Supp
 The SLSA Project oversees development of the SLSA materials in the [SLSA GitHub org](https://github.com/slsa-framework). Specifications developed by the SLSA Project are developed in their own repositories, and are subject to the licensing and governance policies described in this repo.
 
 The SLSA Governance process is based on the [Community Specification model and license](https://github.com/CommunitySpecification/1.0) from the [Joint Development Foundation](https://www.jointdevelopment.org).
+
+## Steering committee
+
+Current steering committee members:
+
+-   [Bruno Domingues](https://github.com/brunodom) - Intel
+-   [David A. Wheeler](https://github.com/david-a-wheeler) - Linux Foundation
+-   [Joshua Lock](https://github.com/joshuagl) - VMware
+-   [Kim Lewandowksi](https://github.com/kimsterv) - Chainguard
+-   [Mark Lodato](https://github.com/MarkLodato) - Google
+-   [Mike Lieberman](https://github.com/mlieberman85) - Kusari/CNCF
+-   [Trishank Karthik Kuppusamy](https://github.com/trishankatdatadog) - Datadog
+
+To contact the steering committee:
+
+-   On GitHub: `@slsa-framework/slsa-steering-committee`
+-   Via email: slsa-steering-committee@googlegroups.com


### PR DESCRIPTION
This makes the governance repo stand-alone. Other repositories will reference this one instead of duplicating the list.
