### PR TITLE
rewrite definition of Maintainer to be more precise

### DIFF
--- a/5._Governance.md
+++ b/5._Governance.md
@@ -14,7 +14,7 @@ The Project includes the following roles. Additional roles may be adopted and do
 
 **1.2. Contributors.** "Contributors" are those Participants that have (a) made Contributions to the Project subject to the Community Specification License; and/or (b) contributed code or documentation to Project assets other than specifications.
 
-**1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of the Project within the guidelines established by the Steering Committee. The specification's Maintainers are listed in [MAINTAINERS.md](https://github.com/slsa-framework/slsa/blob/main/MAINTAINERS.md), while other workstreams may have their own list of Maintainers.
+**1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of the Project within the guidelines established by the Steering Committee. The "Specification Maintainers" are the default set of Maintainers for all Project repositories, recorded in slsa.git's [MAINTAINERS.md](https://github.com/slsa-framework/slsa/blob/main/MAINTAINERS.md). Other Project repositories may have a distinct set of Maintainers, defined in their respective MAINTAINERS.md files.
 
 Maintainers may be added through majority approval of existing Maintainers, based on the following criteria:
 

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -16,7 +16,7 @@ The Project includes the following roles. Additional roles may be adopted and do
 
 **1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of the Project within the guidelines established by the Steering Committee. The specification's Maintainers are listed in [MAINTAINERS.md](https://github.com/slsa-framework/slsa/blob/main/MAINTAINERS.md), while other workstreams may have their own list of Maintainers.
 
-Maintainers may be added through majority approval existing Maintainers, based on the following criteria:
+Maintainers may be added through majority approval of existing Maintainers, based on the following criteria:
 
 *   Demonstrated track record of PR reviews (both quality and quantity of reviews)
 *   Demonstrated thought leadership in the project

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -14,18 +14,19 @@ The Project includes the following roles. Additional roles may be adopted and do
 
 **1.2. Contributors.** "Contributors" are those Participants that have (a) made Contributions to the Project subject to the Community Specification License; and/or (b) contributed code or documentation to Project assets other than specifications.
 
-**1.3. Maintainers.** "Maintainers" are responsible for organizing activities around developing, maintaining, and updating the specification(s) and other assets developed by the Project. Maintainers are also responsible for determining consensus and coordinating appeals. Examples of the responsibility of a Maintainer (directly or by delegation) include:
+**1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of the Project within the guidelines established by the Steering Committee. The specification's Maintainers are listed in [MAINTAINERS.md](https://github.com/slsa-framework/slsa/blob/main/MAINTAINERS.md), while other workstreams may have their own list of Maintainers.
 
-* leading workstream meetings and tracking progress
-* setting the agenda, scheduling meetings and keeping minutes
-* actively engaging with the proposals process, both in GitHub issues and the slsa-proposals repo
-* triaging and prioritizing issues
-* contributing and reviewing pull requests
-* manage the day-to-day planning, operation, organization, deliverables and alignment with other workstreams
-* coordinating efforts with the Steering Committee, other workstreams and other external projects
-* ensuring that the contents of their workstream's materials accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines
+Maintainers may be added through majority approval existing Maintainers, based on the following criteria:
 
-A Contributor may become a Maintainer with the Approval of the Steering Committee. A Maintainer may be removed with the Approval of the Steering Committee. A Steering Committee Member may not deliberate or vote on their own appointment or removal as a Maintainer.
+*   Demonstrated track record of PR reviews (both quality and quantity of reviews)
+*   Demonstrated thought leadership in the project
+*   Demonstrated shepherding of project work and contributors
+
+Maintainers may be removed by explicit resignation, for prolonged inactivity (e.g. 3 or more months with no review comments), for some infraction of the code of conduct, or by consistently demonstrating poor judgment. A proposed removal also requires a majority approval. A Maintainer removed for inactivity should be restored following a sustained resumption of contributions and reviews (a month or more) demonstrating a renewed commitment to the project.
+
+In the extreme event that a majority of existing Maintainers are unavailable to approve additions or removals for an extended period of time, the Steering Committee may add or remove Maintainers to bring the Project back to a functioning state.
+
+<!-- Note: The above text was copied with modification from https://github.com/hyperledger/fabric/blob/main/docs/source/CONTRIBUTING.rst -->
 
 **1.4. Steering Committee Members.** The "Steering Committee" is the body that is responsible for overseeing the overall activities of the Project. The Steering Committee consists of up to 7 Participants (each, a "Steering Committee Member") and will initially consist of the Steering Committee Members so designated as of the date of initial adoption of this SLSA Governance Policy. The Steering Committee will meet regularly as needed, but no less then once per quarter. Examples of the responsibilities of the Steering Committee include:
 


### PR DESCRIPTION
- Better explain the purpose and responsibilities of Maintainers.
- List the criteria and process for adding and removing Maintainers.
- Explicitly note that there are different Maintainers per workstream,
  and point to the specification's MAINTAINERS.md.

This largely copies the text from [Hyperledger Fabric](https://hyperledger-fabric.readthedocs.io/en/latest/CONTRIBUTING.html#maintainers),
which was very close to what we need.
