### PR TITLE
Governance improvements

### DIFF
--- a/5._Governance.md
+++ b/5._Governance.md
@@ -53,7 +53,7 @@ One month before the expiration of a Steering Committee Member term, any Partici
 * Evidence of active participation in the community and being well-versed in SLSA
 * Affiliation / employer
 
-The nomination period should last two weeks. After the nomination period, the voting period should begin and last one week. The Steering Committee Members will then tally the votes and announce the new Steering Committee Members.
+The nomination period should last two weeks. After the nomination period, the voting period should begin and last one week. Participants are eligible to vote for Steering Committee members. The Steering Committee Members will then tally the votes and announce the new Steering Committee Members.
 
 An individual may be nominated for and serve any number of successive terms. However, Steering Committee Members are encouraged to allow other longstanding Participants to contribute as Steering Committee Members. Steering Committee Members are elected by current Participants. Steering Committee Members must resign if they become inactive, by not performing the duties as stated in 1.4. Steering Committee Members may be removed in extraordinary circumstances with an escalation to the OpenSSF TAC.
 

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -34,22 +34,19 @@ In the extreme event that a majority of existing Maintainers are unavailable to 
 **1.4. Steering Committee Members.** The "Steering Committee" is the body that is responsible for overseeing the overall activities of the Project. The Steering Committee consists of 3 to 5 Participants (each, a "Steering Committee Member") and will initially consist of the Steering Committee Members so designated as of the date of initial adoption of this SLSA Governance Policy. The Steering Committee will meet regularly as needed, but no less then once per quarter. Examples of the responsibilities of the Steering Committee include:
 
 * enabling the smooth running of the Project
-* coordinating activities between workstreams and Maintainers
-* collectively reviewing and revising the roadmap on a biannual basis
+* collectively reviewing and revising the Project mission, vision, strategy, and roadmap on a biannual basis
+* publishing quarterly updates suitable for OpenSSF TAC and other working groups' consumption
 * participating in strategic planning, such as coordinating face-to-face meetings or suggesting and approving changes to the governance model
-* creating or restructuring workstreams
+* managing the lifecycle of existing and proposed Work Streams within the Project with the consensus input from the community of Participants
+* creating or restructuring Work Streams
 * responding to specific issues or concerns above and beyond the domain of the various workstreams
 * making decisions when community consensus cannot be reached, pursuant to the appeal process documented below
+* holding Maintainers accountable to the standards of what makes SLSA an effective Project and representative of a diverse community of Participants and Contributors
 
-**1.5. Steering Committee Member Terms.** During the initial year, the Steering Committee Members will agree on grouping themselves into two groups, one to serve an initial two-year term, and the other for an initial one-year term. Thereafter, the Steering Committee Members will serve two year terms.
 
-At the expiration of a Steering Committee Member term, any Participant may submit a nomination to fill the seat. An individual may be nominated for and serve any number of successive terms.
+**1.5. Steering Committee Member Terms.** Steering Committee Members have a one year term.
+At the expiration of a Steering Committee Member term, any Participant may submit a nomination to fill the seat. An individual may be nominated for and serve any number of successive terms. However, Steering Committee Members are encouraged to allow other longstanding Participants to contribute as Steering Committee Members. Steering Committee Members are elected by current Participants. Steering Committee Members must resign if they become inactive. Steering Committee Members may be removed through an extraordinary vote by current Participants.
 
-If a Steering Committee Member resigns or ceases to participate for a significant period of time prior to the end of their term, the remaining Steering Committee Members may choose to remove that Steering Committee Member. If so, the remaining Steering Committee Members will determine whether and when to fill the role.
-
-The Steering Committee may add additional Steering Committee Members as it deems necessary.
-
-After discussion with the nominees for a vacant seat, the Steering Committee will select the new Steering Committee Members from the group of nominees taking into account such things as the nominees’ willingness to take on the role, skills, and level of participation as well as the need to maintain a balanced perspective on the Steering Committee (e.g., no more than two people from the same group of related companies should be on the Steering Committee). A Steering Committee Member nominee may not deliberate or vote on their own appointment.
 
 ## 2. Decision Making.
 

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -43,6 +43,8 @@ Maintainers may be removed by explicit resignation, for prolonged inactivity (e.
 * holding Maintainers accountable to the standards of what makes SLSA an effective Project and representative of a diverse community of Participants and Contributors. In the extreme event that a majority of existing Maintainers are unavailable to approve additions or removals for an extended period of time, the Steering Committee may add or remove Maintainers to bring the Project back to a functioning state
 * administration of slsa-framework GitHub organization, including maintaining team memberships for Maintainers, setting security defaults such as branch protection for the organization, managing secrets, etc.
 
+The Steering Committee will be comprised of Members from a diverse set of affiliations. An affiliation must not be represented more than once on the Steering Committee. If affiliation changes during a Steering Committee Member's term which would cause overrepresentation, a Steering Committee Member from that affiliation must resign.
+
 
 **1.5. Steering Committee Member Terms.** Steering Committee Members have a one year term.
 One month before the expiration of a Steering Committee Member term, any Participant may submit a nomination to fill the seat. A Participant must include the following documentation in their nomination:

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -14,7 +14,7 @@ The Project includes the following roles. Additional roles may be adopted and do
 
 **1.1. Participants.** "Participants" are those that have contributed to or participated in the SLSA community, such as by attending meetings, engaging in conversations on Slack, or commenting on documents.
 
-**1.2. Contributors.** "Contributors" are those Participants that have (a) made Contributions to the Project and/or (b) contributed code or documentation to Project assets other than specifications. E.g. creating a PR, reviewing a PR, and editing a specification in a document.
+**1.2. Contributors.** "Contributors" are those Participants that have (a) made Contributions to the Project (E.g. specification changes) and/or (b) contributed code or documentation to Project assets. E.g. creating a PR, reviewing a PR, and editing a specification in a document.
 
 **1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of a Workstream within the guidelines established by the Steering Committee. Each Workstream will record its Maintainers in a MAINTAINERS.md file in the appropriate repositories + path locations.
 
@@ -32,6 +32,7 @@ Maintainers may be removed by explicit resignation, for prolonged inactivity (e.
 **1.4. Steering Committee Members.** The "Steering Committee" is the body that is responsible for overseeing the overall activities of the Project. The Steering Committee consists of 5 Participants (each, a "Steering Committee Member") and will initially consist of the Steering Committee Members so designated as of the date of initial adoption of this SLSA Governance Policy. The Steering Committee will meet regularly as needed, but no less then once per quarter. Examples of the responsibilities of the Steering Committee include:
 
 * enabling the smooth running of the Project
+* active participation within the community
 * collectively reviewing and revising the Project mission, vision, strategy, and roadmap every 6 months or more frequently if needed, and publishing Steering Committee meetings notes
 * publishing quarterly updates suitable for OpenSSF TAC and other working groups' consumption
 * participating in strategic planning, such as coordinating face-to-face meetings or suggesting and approving changes to the governance model
@@ -50,7 +51,7 @@ One month before the expiration of a Steering Committee Member term, any Partici
 * Evidence of active participation in the community and being well-versed in SLSA
 * Affiliation / employer
 
-An individual may be nominated for and serve any number of successive terms. However, Steering Committee Members are encouraged to allow other longstanding Participants to contribute as Steering Committee Members. Steering Committee Members are elected by current Participants. Steering Committee Members must resign if they become inactive. Steering Committee Members may be removed in extraordinary circumstances with an escalation to the OpenSSF TAC.
+An individual may be nominated for and serve any number of successive terms. However, Steering Committee Members are encouraged to allow other longstanding Participants to contribute as Steering Committee Members. Steering Committee Members are elected by current Participants. Steering Committee Members must resign if they become inactive, by not performing the duties as stated in 1.4. Steering Committee Members may be removed in extraordinary circumstances with an escalation to the OpenSSF TAC.
 
 Nominations and decisions must be publicly recorded, e.g. on GitHub issues or Slack, for transparency.
 

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -31,7 +31,7 @@ In the extreme event that a majority of existing Maintainers are unavailable to 
 
 <!-- Note: The above text was copied with modification from https://github.com/hyperledger/fabric/blob/main/docs/source/CONTRIBUTING.rst -->
 
-**1.4. Steering Committee Members.** The "Steering Committee" is the body that is responsible for overseeing the overall activities of the Project. The Steering Committee consists of 3 to 5 Participants (each, a "Steering Committee Member") and will initially consist of the Steering Committee Members so designated as of the date of initial adoption of this SLSA Governance Policy. The Steering Committee will meet regularly as needed, but no less then once per quarter. Examples of the responsibilities of the Steering Committee include:
+**1.4. Steering Committee Members.** The "Steering Committee" is the body that is responsible for overseeing the overall activities of the Project. The Steering Committee consists of 5 Participants (each, a "Steering Committee Member") and will initially consist of the Steering Committee Members so designated as of the date of initial adoption of this SLSA Governance Policy. The Steering Committee will meet regularly as needed, but no less then once per quarter. Examples of the responsibilities of the Steering Committee include:
 
 * enabling the smooth running of the Project
 * collectively reviewing and revising the Project mission, vision, strategy, and roadmap on a biannual basis
@@ -52,11 +52,11 @@ At the expiration of a Steering Committee Member term, any Participant may submi
 
 **2.1. Consensus-Based Decision Making.** The Project makes decisions through a consensus process ("Approval" or "Approved"). While the agreement of all applicable Participants is preferred, it is not required for consensus. Rather, the Maintainers or Steering Committee (as applicable) will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the applicable Project Participants and nature of support and objections. The Maintainers or Steering Committee (as applicable) will document evidence of consensus in accordance with these requirements.
 
-**2.2. Appeal Process.** Decisions may be appealed be via a pull request or an issue, and that appeal will be considered by the applicable Maintainers in good faith, who will respond in writing within a reasonable time.
+**2.2. Appeal Process.** Decisions may be appealed via a pull request or an issue, and that appeal will be considered by the applicable Maintainers in good faith, who will respond in writing within a reasonable time.
 
 **2.3. Steering Committee Appeal Process.** Decisions that have been appealed to the Maintainers may in extraordinary cases be appealed to the Steering Committee for reconsideration. An appeal to the Steering Committee must specify in detail (1) the specific decision that is being appealed; (2) the basis for contending that the decision was not aligned with the purposes, goals or scope of the Project; and (3) an explanation of why the decision is extraordinary enough to warrant an appeal to the Steering Committee. The appeal will be considered by the Steering Committee in good faith, who will respond in writing within a reasonable time. The Steering Committee may decline to consider appeals that are unexceptional, unfounded or excessive, including because of their repetitive character.
 
-**2.4. Amendments to Governance Documents.** The documents in this Governance repository may be amended by a two-thirds vote of the entire Steering Committee and are subject to approval by The Linux Foundation. However, entries may be added to the Notices file in this Governance repository as described therein.
+**2.4. Amendments to Governance Documents.** The documents in this Governance repository may be amended by four of the five Steering Committee Members and are subject to approval by The Linux Foundation. However, entries may be added to the Notices file in this Governance repository as described therein.
 
 ## 3. Ways of Working.
 

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -6,15 +6,17 @@ As a community effort organized within the [Supply Chain Integrity WG](https://g
 
 The SLSA Project described in this document is the "Working Group" for purposes of the [Community Specification License 1.0](./1._Community_Specification_License-v1.md).
 
+The SLSA Project is comprised of multiple "Work Streams." These Work Streams represent different tracks of specification work or tools implementation. Work Streams are not strictly tied to unique repositories in the slsa-framework GitHub organization. 
+
 ## 1. Roles.
 
 The Project includes the following roles. Additional roles may be adopted and documented by the Steering Committee.
 
-**1.1. Participants.** "Participants" are those that have (a) made Contributions to the Project subject to the Community Specification License; (b) contributed code or documentation to Project assets other than specifications; and/or (c) otherwise contributed to or participated in the SLSA community, such as by attending meetings.
+**1.1. Participants.** "Participants" are those that have contributed to or participated in the SLSA community, such as by attending meetings, engaging in conversations on Slack, or commenting on documents.
 
-**1.2. Contributors.** "Contributors" are those Participants that have (a) made Contributions to the Project subject to the Community Specification License; and/or (b) contributed code or documentation to Project assets other than specifications.
+**1.2. Contributors.** "Contributors" are those Participants that have (a) made Contributions to the Project and/or (b) contributed code or documentation to Project assets other than specifications. E.g. creating a PR, reviewing a PR, and editing a specification in a document.
 
-**1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of the Project within the guidelines established by the Steering Committee. The "Specification Maintainers" are the default set of Maintainers for all Project repositories, recorded in slsa.git's [MAINTAINERS.md](https://github.com/slsa-framework/slsa/blob/main/MAINTAINERS.md). Other Project repositories may have a distinct set of Maintainers, defined in their respective MAINTAINERS.md files.
+**1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of a Work Stream within the guidelines established by the Steering Committee. Each Work Stream will record its Maintainers in a Maintainers.md file in the appropriate repositories + path locations.
 
 Maintainers may be added through majority approval of existing Maintainers, based on the following criteria:
 
@@ -22,13 +24,14 @@ Maintainers may be added through majority approval of existing Maintainers, base
 *   Demonstrated thought leadership in the project
 *   Demonstrated shepherding of project work and contributors
 
-Maintainers may be removed by explicit resignation, for prolonged inactivity (e.g. 3 or more months with no review comments), for some infraction of the code of conduct, or by consistently demonstrating poor judgment. A proposed removal also requires a majority approval. A Maintainer removed for inactivity should be restored following a sustained resumption of contributions and reviews (a month or more) demonstrating a renewed commitment to the project.
+Maintainers may be removed by explicit resignation, for prolonged inactivity (e.g. 3 or more months with no review comments), for some infraction of the code of conduct, or by consistently demonstrating poor judgment. A proposed removal also requires a majority approval. A Maintainer removed for inactivity may be restored following a sustained resumption of contributions and reviews (a month or more) demonstrating a renewed commitment to the project.
 
+## TODO MOVE THIS TO DECISION MAKING
 In the extreme event that a majority of existing Maintainers are unavailable to approve additions or removals for an extended period of time, the Steering Committee may add or remove Maintainers to bring the Project back to a functioning state.
 
 <!-- Note: The above text was copied with modification from https://github.com/hyperledger/fabric/blob/main/docs/source/CONTRIBUTING.rst -->
 
-**1.4. Steering Committee Members.** The "Steering Committee" is the body that is responsible for overseeing the overall activities of the Project. The Steering Committee consists of up to 7 Participants (each, a "Steering Committee Member") and will initially consist of the Steering Committee Members so designated as of the date of initial adoption of this SLSA Governance Policy. The Steering Committee will meet regularly as needed, but no less then once per quarter. Examples of the responsibilities of the Steering Committee include:
+**1.4. Steering Committee Members.** The "Steering Committee" is the body that is responsible for overseeing the overall activities of the Project. The Steering Committee consists of 3 to 5 Participants (each, a "Steering Committee Member") and will initially consist of the Steering Committee Members so designated as of the date of initial adoption of this SLSA Governance Policy. The Steering Committee will meet regularly as needed, but no less then once per quarter. Examples of the responsibilities of the Steering Committee include:
 
 * enabling the smooth running of the Project
 * coordinating activities between workstreams and Maintainers

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -24,7 +24,7 @@ Maintainers may be added through majority approval of existing Maintainers, base
 *   Demonstrated thought leadership in the project
 *   Demonstrated shepherding of project work and contributors
 
-Maintainers may be removed by explicit resignation, for prolonged inactivity (e.g. 3 or more months with no review comments), for some infraction of the code of conduct, or by consistently demonstrating poor judgment. A proposed removal also requires a majority approval. A Maintainer removed for inactivity may be restored following a sustained resumption of contributions and reviews (a month or more) demonstrating a renewed commitment to the project.
+Maintainers may be removed by explicit resignation, for prolonged inactivity (e.g. 3 or more months with no review comments), for some infraction of the code of conduct, or for consistently demonstrating poor judgment. A proposed removal also requires a majority approval. A Maintainer removed for inactivity may be restored following a sustained resumption of contributions and reviews (a month or more) demonstrating a renewed commitment to the project.
 
 
 <!-- Note: The above text was copied with modification from https://github.com/hyperledger/fabric/blob/main/docs/source/CONTRIBUTING.rst -->

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -6,7 +6,7 @@ As a community effort organized within the [Supply Chain Integrity WG](https://g
 
 The SLSA Project described in this document is the "Working Group" for purposes of the [Community Specification License 1.0](./1._Community_Specification_License-v1.md).
 
-The SLSA Project is comprised of multiple "Work Streams." These Work Streams represent different tracks of specification work or tools implementation. Work Streams are not strictly tied to unique repositories in the slsa-framework GitHub organization. 
+The SLSA Project is comprised of multiple "Workstreams." These Workstreams represent different tracks of specification work or tools implementation. Workstreams are not strictly tied to unique repositories in the slsa-framework GitHub organization. 
 
 ## 1. Roles.
 
@@ -16,7 +16,7 @@ The Project includes the following roles. Additional roles may be adopted and do
 
 **1.2. Contributors.** "Contributors" are those Participants that have (a) made Contributions to the Project and/or (b) contributed code or documentation to Project assets other than specifications. E.g. creating a PR, reviewing a PR, and editing a specification in a document.
 
-**1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of a Work Stream within the guidelines established by the Steering Committee. Each Work Stream will record its Maintainers in a MAINTAINERS.md file in the appropriate repositories + path locations.
+**1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of a Workstream within the guidelines established by the Steering Committee. Each Workstream will record its Maintainers in a MAINTAINERS.md file in the appropriate repositories + path locations.
 
 Maintainers may be added through majority approval of existing Maintainers, based on the following criteria:
 
@@ -35,8 +35,8 @@ Maintainers may be removed by explicit resignation, for prolonged inactivity (e.
 * collectively reviewing and revising the Project mission, vision, strategy, and roadmap every 6 months or more frequently if needed, and publishing Steering Committee meetings notes
 * publishing quarterly updates suitable for OpenSSF TAC and other working groups' consumption
 * participating in strategic planning, such as coordinating face-to-face meetings or suggesting and approving changes to the governance model
-* managing the lifecycle of existing and proposed Work Streams within the Project with the consensus input from the community of Participants
-* creating or restructuring Work Streams
+* managing the lifecycle of existing and proposed Workstreams within the Project with the consensus input from the community of Participants
+* creating or restructuring Workstreams
 * responding to specific issues or concerns above and beyond the domain of the various workstreams
 * making decisions when community consensus cannot be reached, pursuant to the appeal process documented below
 * holding Maintainers accountable to the standards of what makes SLSA an effective Project and representative of a diverse community of Participants and Contributors. In the extreme event that a majority of existing Maintainers are unavailable to approve additions or removals for an extended period of time, the Steering Committee may add or remove Maintainers to bring the Project back to a functioning state

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -57,6 +57,8 @@ The nomination period should last two weeks. After the nomination period, the vo
 
 An individual may be nominated for and serve any number of successive terms. However, Steering Committee Members are encouraged to allow other longstanding Participants to contribute as Steering Committee Members. Steering Committee Members are elected by current Participants. Steering Committee Members must resign if they become inactive, by not performing the duties as stated in 1.4. Steering Committee Members may be removed in extraordinary circumstances with an escalation to the OpenSSF TAC.
 
+When a Steering Committee Member resigns or is removed, an election must be held to replace the Member, following the procedure for nominations and elections as discussed above.
+
 Nominations and decisions must be publicly recorded, e.g. on GitHub issues or Slack, for transparency.
 
 

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -16,7 +16,7 @@ The Project includes the following roles. Additional roles may be adopted and do
 
 **1.2. Contributors.** "Contributors" are those Participants that have (a) made Contributions to the Project and/or (b) contributed code or documentation to Project assets other than specifications. E.g. creating a PR, reviewing a PR, and editing a specification in a document.
 
-**1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of a Work Stream within the guidelines established by the Steering Committee. Each Work Stream will record its Maintainers in a Maintainers.md file in the appropriate repositories + path locations.
+**1.3. Maintainers.** "Maintainers" are responsible for reviewing and merging all proposed changes, and they guide the overall technical direction of a Work Stream within the guidelines established by the Steering Committee. Each Work Stream will record its Maintainers in a MAINTAINERS.md file in the appropriate repositories + path locations.
 
 Maintainers may be added through majority approval of existing Maintainers, based on the following criteria:
 
@@ -32,7 +32,7 @@ Maintainers may be removed by explicit resignation, for prolonged inactivity (e.
 **1.4. Steering Committee Members.** The "Steering Committee" is the body that is responsible for overseeing the overall activities of the Project. The Steering Committee consists of 5 Participants (each, a "Steering Committee Member") and will initially consist of the Steering Committee Members so designated as of the date of initial adoption of this SLSA Governance Policy. The Steering Committee will meet regularly as needed, but no less then once per quarter. Examples of the responsibilities of the Steering Committee include:
 
 * enabling the smooth running of the Project
-* collectively reviewing and revising the Project mission, vision, strategy, and roadmap on a biannual basis
+* collectively reviewing and revising the Project mission, vision, strategy, and roadmap every 6 months or more frequently if needed, and publishing Steering Committee meetings notes
 * publishing quarterly updates suitable for OpenSSF TAC and other working groups' consumption
 * participating in strategic planning, such as coordinating face-to-face meetings or suggesting and approving changes to the governance model
 * managing the lifecycle of existing and proposed Work Streams within the Project with the consensus input from the community of Participants
@@ -40,10 +40,19 @@ Maintainers may be removed by explicit resignation, for prolonged inactivity (e.
 * responding to specific issues or concerns above and beyond the domain of the various workstreams
 * making decisions when community consensus cannot be reached, pursuant to the appeal process documented below
 * holding Maintainers accountable to the standards of what makes SLSA an effective Project and representative of a diverse community of Participants and Contributors. In the extreme event that a majority of existing Maintainers are unavailable to approve additions or removals for an extended period of time, the Steering Committee may add or remove Maintainers to bring the Project back to a functioning state
+* administration of slsa-framework GitHub organization, including maintaining team memberships for Maintainers, setting security defaults such as branch protection for the organization, managing secrets, etc.
 
 
 **1.5. Steering Committee Member Terms.** Steering Committee Members have a one year term.
-At the expiration of a Steering Committee Member term, any Participant may submit a nomination to fill the seat. An individual may be nominated for and serve any number of successive terms. However, Steering Committee Members are encouraged to allow other longstanding Participants to contribute as Steering Committee Members. Steering Committee Members are elected by current Participants. Steering Committee Members must resign if they become inactive. Steering Committee Members may be removed through an extraordinary vote by current Participants.
+One month before the expiration of a Steering Committee Member term, any Participant may submit a nomination to fill the seat. A Participant must include the following documentation in their nomination:
+
+* Statement of intent to perform the duties of a Steering Committee Member during the next term
+* Evidence of active participation in the community and being well-versed in SLSA
+* Affiliation / employer
+
+An individual may be nominated for and serve any number of successive terms. However, Steering Committee Members are encouraged to allow other longstanding Participants to contribute as Steering Committee Members. Steering Committee Members are elected by current Participants. Steering Committee Members must resign if they become inactive. Steering Committee Members may be removed in extraordinary circumstances with an escalation to the OpenSSF TAC.
+
+Nominations and decisions must be publicly recorded, e.g. on GitHub issues or Slack, for transparency.
 
 
 ## 2. Decision Making.

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -53,6 +53,8 @@ One month before the expiration of a Steering Committee Member term, any Partici
 * Evidence of active participation in the community and being well-versed in SLSA
 * Affiliation / employer
 
+The nomination period should last two weeks. After the nomination period, the voting period should begin and last one week. The Steering Committee Members will then tally the votes and announce the new Steering Committee Members.
+
 An individual may be nominated for and serve any number of successive terms. However, Steering Committee Members are encouraged to allow other longstanding Participants to contribute as Steering Committee Members. Steering Committee Members are elected by current Participants. Steering Committee Members must resign if they become inactive, by not performing the duties as stated in 1.4. Steering Committee Members may be removed in extraordinary circumstances with an escalation to the OpenSSF TAC.
 
 Nominations and decisions must be publicly recorded, e.g. on GitHub issues or Slack, for transparency.

--- a/5._Governance.md
+++ b/5._Governance.md
@@ -26,8 +26,6 @@ Maintainers may be added through majority approval of existing Maintainers, base
 
 Maintainers may be removed by explicit resignation, for prolonged inactivity (e.g. 3 or more months with no review comments), for some infraction of the code of conduct, or by consistently demonstrating poor judgment. A proposed removal also requires a majority approval. A Maintainer removed for inactivity may be restored following a sustained resumption of contributions and reviews (a month or more) demonstrating a renewed commitment to the project.
 
-## TODO MOVE THIS TO DECISION MAKING
-In the extreme event that a majority of existing Maintainers are unavailable to approve additions or removals for an extended period of time, the Steering Committee may add or remove Maintainers to bring the Project back to a functioning state.
 
 <!-- Note: The above text was copied with modification from https://github.com/hyperledger/fabric/blob/main/docs/source/CONTRIBUTING.rst -->
 
@@ -41,7 +39,7 @@ In the extreme event that a majority of existing Maintainers are unavailable to 
 * creating or restructuring Work Streams
 * responding to specific issues or concerns above and beyond the domain of the various workstreams
 * making decisions when community consensus cannot be reached, pursuant to the appeal process documented below
-* holding Maintainers accountable to the standards of what makes SLSA an effective Project and representative of a diverse community of Participants and Contributors
+* holding Maintainers accountable to the standards of what makes SLSA an effective Project and representative of a diverse community of Participants and Contributors. In the extreme event that a majority of existing Maintainers are unavailable to approve additions or removals for an extended period of time, the Steering Committee may add or remove Maintainers to bring the Project back to a functioning state
 
 
 **1.5. Steering Committee Member Terms.** Steering Committee Members have a one year term.


### PR DESCRIPTION
Updated terms and roles to more accurately reflect the current working group norms and future efforts.
Updated Steering Committee Member terms and elections and responsibilities.
Changed the Steering Committee size to exactly 5 and updated rules for governance update to depend on that size

Still missing some text to encourage Maintainers of Work Streams to make decisions more quickly in a smaller setting. This probably belongs in the Work Stream lifecycle rather than governance. 